### PR TITLE
Add the last comma for restore load 'ul' tag in Markdown allowlist

### DIFF
--- a/bleach_allowlist/bleach_allowlist.py
+++ b/bleach_allowlist/bleach_allowlist.py
@@ -54,7 +54,7 @@ markdown_tags = [
     "h1", "h2", "h3", "h4", "h5", "h6",
     "b", "i", "strong", "em", "tt",
     "p", "br",
-    "span", "div", "blockquote", "code", "pre", "hr"
+    "span", "div", "blockquote", "code", "pre", "hr",
     "ul", "ol", "li", "dd", "dt",
     "img",
     "a",


### PR DESCRIPTION
A previous commit has removed the next element "ul" in Python syntax.
https://github.com/yourcelf/bleach-allowlist/commit/8cbff790a829a8738902ec62aebd7ccb3025d7a9

I have confirmed that the ul tag is not found in the code below.
```python
import bleach_allowlist

print(bleach_allowlist.bleach_allowlist.markdown_tags)
# ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'b', 'i', 'strong', 'em', 'tt', 'p', 'br', 'span', 'div', 'blockquote', 'code', 'pre', 'hrul', 'ol', 'li', 'dd', 'dt', 'img', 'a', 'sub', 'sup']
```